### PR TITLE
Updating to new reMarkable annotations format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
#4 should be fixed with this PR, but you need to use [this version of rm2svg](https://www.ucl.ac.uk/~ucecesf/tmp/rm2svg.py). ImageMagick is not optional anymore since I had to generate a blank pdf. On macOS Mojave, latest pdftk version will hang, so I suggest using [pdftk_server-2.02-mac_osx-10.11-setup file](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.11-setup.pkg) instead.

- Look now for `.rm` files instead of `.lines` ones.
- Fill pages with no annotations with a blank pdf for merging.

Feel free to put this PR in a WIP state as I generated a letter size blank pdf, which I'm not sure will work well with other size documents. I also didn't test for resized pdf for lack of time right now... There is probably a better way to do what I wanted to achieve (not sure if reMarkable was generating a `.lines` file for pages that had no no annotations before, but it's not the case for the new one) by filling remaining pages with a blank one. I don't know much about pdfunite (I didn't find any options as it's the intended behaviour for `--multistamp`, but without that, the last annotations were repeated in all pages from the original pdf without annotations.