### PR TITLE
Account for empty pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ All these things need to be on your path, and you need to have given `rmapi` acc
 * ImageMagick (`convert`)
 * pdfinfo (from poppler-utils)
 * pdfunite (from poppler-utils)
-* pdftk
+* qpdf
 * [rmapi](https://github.com/juruen/rmapi)
 * [rM2svg](https://github.com/reHackable/maxio/blob/master/tools/rM2svg)
 * [svgexport](https://github.com/shakiba/svgexport)
@@ -47,7 +47,7 @@ And the following Python libraries:
 On Ubuntu:
 
 ```
-sudo apt install imagemagick poppler-utils pdftk
+sudo apt install imagemagick poppler-utils qpdf
 pip install opencv-python numpy
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,22 +20,39 @@ rm-dl-annotated.sh "/Super Cool Research Paper I Scribbled All Over"
 
 Generates `./"Super Cool Research Paper (exported).pdf"` with the scribbles on top of the original PDF.
 
-## Dependencies:
+## Dependencies
 
 All these things need to be on your path, and you need to have given `rmapi` access to your ReMarkable Cloud account:
 
 * python
 * ImageMagick (`convert`)
+* pdfinfo (from poppler-utils)
+* pdfunite (from poppler-utils)
+* pdftk
 * [rmapi](https://github.com/juruen/rmapi)
 * [rM2svg](https://github.com/reHackable/maxio/blob/master/tools/rM2svg)
 * [svgexport](https://github.com/shakiba/svgexport)
-* pdfinfo
-* pdfunite
-* pdftk
 
 If any of your PDFs have been cropped on your ReMarkable then you will also need:
 
-* opencv-python
-* numpy
-* pdftoppm
+* pdftoppm (from poppler-utils)
+
+And the following Python libraries:
+
+* [opencv-python](https://pypi.org/project/opencv-python/)
+* [numpy](https://numpy.org/)
+
+## Installation
+
+On Ubuntu:
+
+```
+sudo apt install imagemagick poppler-utils pdftk
+pip install opencv-python numpy
+```
+
+Follow the installation instructions on the project pages for
+[rmapi](https://github.com/juruen/rmapi),
+[rM2svg](https://github.com/reHackable/maxio/blob/master/tools/rM2svg), and
+[svgexport](https://github.com/shakiba/svgexport).
 

--- a/rm-dl-annotated.sh
+++ b/rm-dl-annotated.sh
@@ -107,6 +107,7 @@ fi
 # Convert the lines file containing our scribbles to SVGs and then a PDF
 
 OUT_WIDTH="$RM_WIDTH"
+OUT_HEIGHT="$RM_HEIGHT"
 
 if [ -z "$IS_NOTEBOOK" ]; then
   PDF_DIMS=$(pdfinfo "$UUID".pdf | grep "Page size" | grep -Eo '[-+]?[0-9]*\.?[0-9]+' | tr '\n' ' ')
@@ -122,15 +123,8 @@ for i in $(seq 0 $NUM_PAGES ); do
   else 
 	  cat <<EOT >> "./$svg_file"
 <svg xmlns="http://www.w3.org/2000/svg" height="1872" width="10.0">
-        <script type="application/ecmascript"> <![CDATA[
-            var visiblePage = 'p1';
-            function goToPage(page) {
-                document.getElementById(visiblePage).setAttribute('style', 'display: none');
-                document.getElementById(page).setAttribute('style', 'display: inline');
-                visiblePage = page;
-            }
-        ]]> </script>
-    <g id="p1" style="display:inline"><rect x="0" y="0" width="$OUT_WIDTH" height="1872" fill-opacity="0"/></g></svg>
+    <g id="p1" style="display:inline"><rect x="0" y="0" width="$OUT_WIDTH" height="$OUT_HEIGHT" fill-opacity="0"/></g>
+</svg>
 EOT
   fi
 done

--- a/rm-dl-annotated.sh
+++ b/rm-dl-annotated.sh
@@ -9,7 +9,7 @@
 # * svgexport https://github.com/shakiba/svgexport
 # * pdfinfo
 # * pdfunite
-# * pdftk
+# * qpdf
 # * pdftoppm (if you use cropping)
 
 set -o errexit
@@ -166,7 +166,7 @@ fi
 OUTPUT_PDF="$OBJECT_NAME (exported).pdf"
 if [ -z "$IS_NOTEBOOK" ]; then
   # Layer the annotations onto the original PDF
-  pdftk "$UUID".pdf multistamp "$PDF_ANNOTATIONS" output "$OUTPUT_PDF"
+  qpdf "$UUID".pdf --overlay "$PDF_ANNOTATIONS" -- "$OUTPUT_PDF"
 else
   cp "$PDF_ANNOTATIONS" "$OUTPUT_PDF"
 fi

--- a/rm-dl-annotated.sh
+++ b/rm-dl-annotated.sh
@@ -111,11 +111,28 @@ OUT_WIDTH="$RM_WIDTH"
 if [ -z "$IS_NOTEBOOK" ]; then
   PDF_DIMS=$(pdfinfo "$UUID".pdf | grep "Page size" | grep -Eo '[-+]?[0-9]*\.?[0-9]+' | tr '\n' ' ')
   OUT_WIDTH=$(echo $PDF_DIMS | awk -v height=$RM_HEIGHT '{print $1 / $2 * height}')
+  NUM_PAGES=$(pdfinfo "$UUID".pdf |grep Pages | awk '{print $2}')
 fi
 
-for lines_file in "$UUID"/*.rm; do
+for i in $(seq 0 $NUM_PAGES ); do 
+  lines_file="$UUID/$i.rm"
   svg_file=$(basename "$lines_file" .rm).svg
-  rM2svg --width=$OUT_WIDTH --coloured_annotations -i "./$lines_file" -o "./$svg_file"
+  if test -f "./$lines_file"; then
+	  rM2svg --width=$OUT_WIDTH --coloured_annotations -i "./$lines_file" -o "./$svg_file"
+  else 
+	  cat <<EOT >> "./$svg_file"
+<svg xmlns="http://www.w3.org/2000/svg" height="1872" width="10.0">
+        <script type="application/ecmascript"> <![CDATA[
+            var visiblePage = 'p1';
+            function goToPage(page) {
+                document.getElementById(visiblePage).setAttribute('style', 'display: none');
+                document.getElementById(page).setAttribute('style', 'display: inline');
+                visiblePage = page;
+            }
+        ]]> </script>
+    <g id="p1" style="display:inline"><rect x="0" y="0" width="$OUT_WIDTH" height="1872" fill-opacity="0"/></g></svg>
+EOT
+  fi
 done
 
 if [ $IS_TRANSFORMED = true ]; then


### PR DESCRIPTION
At least for recent reMarkable versions (2.1.x), there is no .rm file when there is no annotation on a given page. The consequence is a misaligned set of annotations for subsequent pages.
This PR implements a simple solution, by generating an empty svg in that case.

Note that it includes changes from the other PR I made to move to qpdf.